### PR TITLE
Remove "applyCql" parameter from CQF Ruler Tests

### DIFF
--- a/specification/CreateCQFRulerInput.py
+++ b/specification/CreateCQFRulerInput.py
@@ -20,7 +20,6 @@ for patient_folder in os.listdir(patient_directory):
           "hookInstance": "test",
           "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
           "hook": "patient-view",
-          "applyCql": False,
           "context": {
             "userId": "Practitioner/example",
             "patientId": "patient-id"

--- a/tests/requests/AdverseEvents/cqfruler-AE-Excluded.json
+++ b/tests/requests/AdverseEvents/cqfruler-AE-Excluded.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "AE-Excluded"

--- a/tests/requests/AdverseEvents/cqfruler-AE-TreatedAdverseEvent.json
+++ b/tests/requests/AdverseEvents/cqfruler-AE-TreatedAdverseEvent.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "AE-TreatedAdverseEvent"

--- a/tests/requests/AdverseEvents/cqfruler-AE-TreatedAndUntreated.json
+++ b/tests/requests/AdverseEvents/cqfruler-AE-TreatedAndUntreated.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "AE-TreatedAndUntreated"

--- a/tests/requests/AdverseEvents/cqfruler-AE-UntreatedAdverseEvent.json
+++ b/tests/requests/AdverseEvents/cqfruler-AE-UntreatedAdverseEvent.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "AE-UntreatedAdverseEvent"

--- a/tests/requests/CQFRulerTests2.py
+++ b/tests/requests/CQFRulerTests2.py
@@ -8,7 +8,7 @@ import re
 import requests
 
 cqf_ruler_url = "http://localhost:8080/cds-services/plandefinition-"
-only_folders = ['Pharma']
+only_folders = []
 only_files = []
 
 for folder in os.listdir("."):

--- a/tests/requests/Hypertension/cqfruler-H-ConsiderHTNStage1.json
+++ b/tests/requests/Hypertension/cqfruler-H-ConsiderHTNStage1.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ConsiderHTNStage1"

--- a/tests/requests/Hypertension/cqfruler-H-ConsiderHTNStage2.json
+++ b/tests/requests/Hypertension/cqfruler-H-ConsiderHTNStage2.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ConsiderHTNStage2"

--- a/tests/requests/Hypertension/cqfruler-H-ExcludedEndStageRenalDisease.json
+++ b/tests/requests/Hypertension/cqfruler-H-ExcludedEndStageRenalDisease.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ExcludedEndStageRenalDisease"

--- a/tests/requests/Hypertension/cqfruler-H-ExcludedOver80.json
+++ b/tests/requests/Hypertension/cqfruler-H-ExcludedOver80.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ExcludedOver80"

--- a/tests/requests/Hypertension/cqfruler-H-ExcludedPregnant.json
+++ b/tests/requests/Hypertension/cqfruler-H-ExcludedPregnant.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ExcludedPregnant"

--- a/tests/requests/Hypertension/cqfruler-H-ExcludedPregnantEncounterDiagnosis.json
+++ b/tests/requests/Hypertension/cqfruler-H-ExcludedPregnantEncounterDiagnosis.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ExcludedPregnantEncounterDiagnosis"

--- a/tests/requests/Hypertension/cqfruler-H-ExcludedUnder18.json
+++ b/tests/requests/Hypertension/cqfruler-H-ExcludedUnder18.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-ExcludedUnder18"

--- a/tests/requests/Hypertension/cqfruler-H-HTNStage2AverageBPSetHome.json
+++ b/tests/requests/Hypertension/cqfruler-H-HTNStage2AverageBPSetHome.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-HTNStage2AverageBPSetHome"

--- a/tests/requests/Hypertension/cqfruler-H-HTNStage2AverageBPSetOffice.json
+++ b/tests/requests/Hypertension/cqfruler-H-HTNStage2AverageBPSetOffice.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-HTNStage2AverageBPSetOffice"

--- a/tests/requests/Hypertension/cqfruler-H-HTNStage2LastBPSetHome.json
+++ b/tests/requests/Hypertension/cqfruler-H-HTNStage2LastBPSetHome.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-HTNStage2LastBPSetHome"

--- a/tests/requests/Hypertension/cqfruler-H-HTNStage2LastBPSetOffice.json
+++ b/tests/requests/Hypertension/cqfruler-H-HTNStage2LastBPSetOffice.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-HTNStage2LastBPSetOffice"

--- a/tests/requests/Hypertension/cqfruler-H-MonitoringPreexistingHTN.json
+++ b/tests/requests/Hypertension/cqfruler-H-MonitoringPreexistingHTN.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-MonitoringPreexistingHTN"

--- a/tests/requests/Hypertension/cqfruler-H-NoFurtherAction.json
+++ b/tests/requests/Hypertension/cqfruler-H-NoFurtherAction.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-NoFurtherAction"

--- a/tests/requests/Hypertension/cqfruler-H-PrescribeAmbulatoryBPMonitoring.json
+++ b/tests/requests/Hypertension/cqfruler-H-PrescribeAmbulatoryBPMonitoring.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-PrescribeAmbulatoryBPMonitoring"

--- a/tests/requests/Hypertension/cqfruler-H-PrescribeHBPABPMonitoring.json
+++ b/tests/requests/Hypertension/cqfruler-H-PrescribeHBPABPMonitoring.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-PrescribeHBPABPMonitoring"

--- a/tests/requests/Hypertension/cqfruler-H-RecommendMoreBPs.json
+++ b/tests/requests/Hypertension/cqfruler-H-RecommendMoreBPs.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-RecommendMoreBPs"

--- a/tests/requests/Hypertension/cqfruler-H-SeparateBPObservations.json
+++ b/tests/requests/Hypertension/cqfruler-H-SeparateBPObservations.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "H-SeparateBPObservations"

--- a/tests/requests/HypertensiveEmergency/cqfruler-HE-ExcludedBPNotRecent.json
+++ b/tests/requests/HypertensiveEmergency/cqfruler-HE-ExcludedBPNotRecent.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "HE-ExcludedBPNotRecent"

--- a/tests/requests/HypertensiveEmergency/cqfruler-HE-ExcludedNoHypertensiveBP.json
+++ b/tests/requests/HypertensiveEmergency/cqfruler-HE-ExcludedNoHypertensiveBP.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "HE-ExcludedNoHypertensiveBP"

--- a/tests/requests/HypertensiveEmergency/cqfruler-HE-HypertensiveEmergencyEffective.json
+++ b/tests/requests/HypertensiveEmergency/cqfruler-HE-HypertensiveEmergencyEffective.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "HE-HypertensiveEmergencyEffective"

--- a/tests/requests/HypertensiveEmergency/cqfruler-HE-HypertensiveEmergencyIssued.json
+++ b/tests/requests/HypertensiveEmergency/cqfruler-HE-HypertensiveEmergencyIssued.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "HE-HypertensiveEmergencyIssued"

--- a/tests/requests/Monitoring/cqfruler-Adolph80-Turcotte120.json
+++ b/tests/requests/Monitoring/cqfruler-Adolph80-Turcotte120.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "Adolph80-Turcotte120"

--- a/tests/requests/Monitoring/cqfruler-M-BPControlledVarHigh.json
+++ b/tests/requests/Monitoring/cqfruler-M-BPControlledVarHigh.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-BPControlledVarHigh"

--- a/tests/requests/Monitoring/cqfruler-M-BPControlledVarLow.json
+++ b/tests/requests/Monitoring/cqfruler-M-BPControlledVarLow.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-BPControlledVarLow"

--- a/tests/requests/Monitoring/cqfruler-M-BPUncontrolledVarHigh.json
+++ b/tests/requests/Monitoring/cqfruler-M-BPUncontrolledVarHigh.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-BPUncontrolledVarHigh"

--- a/tests/requests/Monitoring/cqfruler-M-BPUncontrolledVarLow.json
+++ b/tests/requests/Monitoring/cqfruler-M-BPUncontrolledVarLow.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-BPUncontrolledVarLow"

--- a/tests/requests/Monitoring/cqfruler-M-ConditionBySystemOID.json
+++ b/tests/requests/Monitoring/cqfruler-M-ConditionBySystemOID.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-ConditionBySystemOID"

--- a/tests/requests/Monitoring/cqfruler-M-ExcludedEndStageRenalDisease.json
+++ b/tests/requests/Monitoring/cqfruler-M-ExcludedEndStageRenalDisease.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-ExcludedEndStageRenalDisease"

--- a/tests/requests/Monitoring/cqfruler-M-ExcludedNotDiagnosed.json
+++ b/tests/requests/Monitoring/cqfruler-M-ExcludedNotDiagnosed.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-ExcludedNotDiagnosed"

--- a/tests/requests/Monitoring/cqfruler-M-ExcludedOver80.json
+++ b/tests/requests/Monitoring/cqfruler-M-ExcludedOver80.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-ExcludedOver80"

--- a/tests/requests/Monitoring/cqfruler-M-ExcludedPregnant.json
+++ b/tests/requests/Monitoring/cqfruler-M-ExcludedPregnant.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-ExcludedPregnant"

--- a/tests/requests/Monitoring/cqfruler-M-ExcludedUnder18.json
+++ b/tests/requests/Monitoring/cqfruler-M-ExcludedUnder18.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-ExcludedUnder18"

--- a/tests/requests/Monitoring/cqfruler-M-NotAtGoalAboveGoal.json
+++ b/tests/requests/Monitoring/cqfruler-M-NotAtGoalAboveGoal.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-NotAtGoalAboveGoal"

--- a/tests/requests/Monitoring/cqfruler-M-NotAtGoalHTNStage2.json
+++ b/tests/requests/Monitoring/cqfruler-M-NotAtGoalHTNStage2.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-NotAtGoalHTNStage2"

--- a/tests/requests/Monitoring/cqfruler-M-PatientAtGoal.json
+++ b/tests/requests/Monitoring/cqfruler-M-PatientAtGoal.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-PatientAtGoal"

--- a/tests/requests/Monitoring/cqfruler-M-RecommendAmbulatoryBPMonitoring.json
+++ b/tests/requests/Monitoring/cqfruler-M-RecommendAmbulatoryBPMonitoring.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-RecommendAmbulatoryBPMonitoring"

--- a/tests/requests/Monitoring/cqfruler-M-RecommendMoreBPs.json
+++ b/tests/requests/Monitoring/cqfruler-M-RecommendMoreBPs.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-RecommendMoreBPs"

--- a/tests/requests/Monitoring/cqfruler-M-SameDayCondition.json
+++ b/tests/requests/Monitoring/cqfruler-M-SameDayCondition.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-SameDayCondition"

--- a/tests/requests/Monitoring/cqfruler-M-SetBPGoalMissingGoal.json
+++ b/tests/requests/Monitoring/cqfruler-M-SetBPGoalMissingGoal.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "M-SetBPGoalMissingGoal"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ActivityCounseling.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ActivityCounseling.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ActivityCounseling"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ActivityGoalExists.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ActivityGoalExists.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ActivityGoalExists"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ActivityReminder.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ActivityReminder.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ActivityReminder"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationAchieved.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationAchieved.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-AlcoholModerationAchieved"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationConditionDetected.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationConditionDetected.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-AlcoholModerationConditionDetected"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationGoalExists.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationGoalExists.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-AlcoholModerationGoalExists"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationNew.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationNew.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-AlcoholModerationNew"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationReminder.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AlcoholModerationReminder.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-AlcoholModerationReminder"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AllCounselingRecommended.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-AllCounselingRecommended.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-AllCounselingRecommended"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BPGoalInProgress.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BPGoalInProgress.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-BPGoalInProgress"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BPGoalMet.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BPGoalMet.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-BPGoalMet"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BPGoalNotMetRecentProgress.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BPGoalNotMetRecentProgress.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-BPGoalNotMetRecentProgress"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BehaviorGoalExists.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-BehaviorGoalExists.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-BehaviorGoalExists"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-DietaryCounseling.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-DietaryCounseling.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-DietaryCounseling"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-DietaryGoalExists.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-DietaryGoalExists.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-DietaryGoalExists"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-DietaryReminder.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-DietaryReminder.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-DietaryReminder"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-EndNonPharmacologicRecommendations.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-EndNonPharmacologicRecommendations.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-EndNonPharmacologicRecommendations"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedEndStageRenalDisease.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedEndStageRenalDisease.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ExcludedEndStageRenalDisease"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedNotDiagnosed.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedNotDiagnosed.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ExcludedNotDiagnosed"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedOver80.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedOver80.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ExcludedOver80"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedPregnant.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedPregnant.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ExcludedPregnant"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedUnder18.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-ExcludedUnder18.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-ExcludedUnder18"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldAlcoholCounseling.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldAlcoholCounseling.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-OldAlcoholCounseling"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldAlcoholObservation.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldAlcoholObservation.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-OldAlcoholObservation"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldBMI.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldBMI.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-OldBMI"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldSmokingCounseling.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldSmokingCounseling.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-OldSmokingCounseling"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldSmokingObservation.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-OldSmokingObservation.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-OldSmokingObservation"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-PharmacologicInterventions.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-PharmacologicInterventions.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-PharmacologicInterventions"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SetBPGoalMissingGoal.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SetBPGoalMissingGoal.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-SetBPGoalMissingGoal"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationGoalExists.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationGoalExists.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-SmokingCessationGoalExists"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationNew.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationNew.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-SmokingCessationNew"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationQuit.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationQuit.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-SmokingCessationQuit"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationReminder.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-SmokingCessationReminder.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-SmokingCessationReminder"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossAchieved.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossAchieved.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-WeightLossAchieved"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossGoalExists.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossGoalExists.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-WeightLossGoalExists"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossNew.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossNew.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-WeightLossNew"

--- a/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossReminder.json
+++ b/tests/requests/NonPharmacologicIntervention/cqfruler-NPI-WeightLossReminder.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "NPI-WeightLossReminder"

--- a/tests/requests/Pharma/cqfruler-P-AdvancingTreatment.json
+++ b/tests/requests/Pharma/cqfruler-P-AdvancingTreatment.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "P-AdvancingTreatment"

--- a/tests/requests/Pharma/cqfruler-P-AdvancingTreatmentCodeableConcept.json
+++ b/tests/requests/Pharma/cqfruler-P-AdvancingTreatmentCodeableConcept.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "P-AdvancingTreatmentCodeableConcept"

--- a/tests/requests/Pharma/cqfruler-P-InitialPharmacology.json
+++ b/tests/requests/Pharma/cqfruler-P-InitialPharmacology.json
@@ -2,7 +2,6 @@
   "hookInstance": "test",
   "fhirServer": "https://api.logicahealth.org/htnu18r42/open",
   "hook": "patient-view",
-  "applyCql": false,
   "context": {
     "userId": "Practitioner/example",
     "patientId": "P-InitialPharmacology"


### PR DESCRIPTION
This parameter is unnecessary in CQF Ruler 0.5.0 and causes errors in later versions.